### PR TITLE
fix: Fix jen init cmd returns invalid value for base job selection

### DIFF
--- a/lib/cli-table.js
+++ b/lib/cli-table.js
@@ -1,5 +1,6 @@
 const Table = require('cli-table');
 const { gray } = require('kleur');
+const qs = require('querystring');
 const buildStatus = require('./build-status');
 const { formatTimestampToDate, formatMs } = require('./util');
 
@@ -65,7 +66,7 @@ exports.printConfig = function(config) {
     { URL: config.url }
   );
 
-  if (config.job) table.push({ 'Base Job': config.job });
+  if (config.job) table.push({ 'Base Job': qs.unescape(config.job) });
 
   console.log(table.toString());
 };

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -1,13 +1,43 @@
 const prompts = require('prompts');
 const ora = require('ora');
+const qs = require('querystring');
 const { getBaseJobs } = require('./jenkins');
 const { isValidUrl } = require('./util');
 const { logNetworkErrors } = require('./log');
 
-const spinner = ora('Fetching Base Jobs'); // todo: better loading name
+const spinner = ora('Fetching Base Jobs');
+
+function getBaseJobQuestionConfig() {
+  let baseJobs = null;
+
+  return {
+    type: async (prev, answers) => {
+      spinner.start();
+
+      try {
+        const { jobs } = await getBaseJobs(answers);
+
+        // skip the prompt if the jobs list is empty
+        if (!jobs.length) return null;
+
+        baseJobs = jobs.map(job => ({ title: job.name, value: qs.escape(job.name) }));
+        spinner.stop();
+
+        // prompt `type`
+        return 'select';
+      } catch (err) {
+        spinner.stop();
+        logNetworkErrors(err);
+        process.exit();
+      }
+    },
+    name: 'job',
+    message: 'Select current repo base job', // fixme - better message
+    choices: () => baseJobs
+  };
+}
 
 exports.requestJenkinsCredentials = function() {
-  let baseJobs = null;
   const questions = [
     {
       type: 'text',
@@ -38,32 +68,7 @@ exports.requestJenkinsCredentials = function() {
         return val;
       }
     },
-    {
-      // todo - create separate function to retrieve `type`, easy to write test as well
-      type: async (prev, answers) => {
-        spinner.start();
-
-        try {
-          const { jobs } = await getBaseJobs(answers);
-
-          // skip the prompt if the jobs list is empty
-          if (!jobs.length) return null;
-
-          baseJobs = jobs.map(job => job.name);
-          spinner.stop();
-
-          // prompt `type`
-          return 'select';
-        } catch (err) {
-          spinner.stop();
-          logNetworkErrors(err);
-          process.exit();
-        }
-      },
-      name: 'job',
-      message: 'Select current repo base job', // fixme - better message
-      choices: () => baseJobs
-    }
+    getBaseJobQuestionConfig()
   ];
 
   // todo: show banner message about jenkins credentials
@@ -76,7 +81,7 @@ exports.askConfirmation = function() {
     type: 'confirm',
     name: 'confirmation',
     message: 'Are you sure you want to save this configuration?',
-    initial: false
+    initial: true
   };
 
   return prompts(question);


### PR DESCRIPTION
* Added `value` field for base job choices to make sure prompt selection
returns base job name instead of index
* Converted base job name to url safe value