### PR TITLE
feat: Debugging improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Jenkins personal assistant
 
 Options:
   -v, --version       output the version number
+  -d, --debug         Enable debug mode
   -h, --help          output usage information
 
 Commands:
@@ -60,9 +61,13 @@ Commands:
 | `jen config` \| `c` | `--username` \| `-n` <br> `--token` \| `-t`  <br> `--url` \| `-u` <br> `--job` \| `-j` <br> <br> e.g. Reconfigure username & token <br> `jen config --username <foo> --token <bar>` | Overwrite project jenni config. Without any options it will print current config. |
 
 ## Debug
-It's basic for the moment, but you can use `DEBUG_JEN=true` to log debug messages. E.g
+It's basic for the moment, pass `-d` or `--debug` to log debug messages. Can also be enabled by setting the environment variable `DEBUG_JEN` to `true`. E.g. 
 
 ```
+> jen status -d
+
+// OR
+
 > DEBUG_JEN=true jen status
 ```
 

--- a/bin/jen.js
+++ b/bin/jen.js
@@ -5,9 +5,20 @@ const pkg = require('../package.json');
 const { init, status, config, open } = require('../src');
 const { debug } = require('../lib/log');
 
-debug(`jen v${pkg.version}`);
+const args = process.argv.slice(2);
 
-jen.version(pkg.version, '-v, --version').description('Jenkins personal assistant');
+// Why manual check instead of `jen.debug`?
+// Because we have to enable the debug before initializing jen: `jen.parse(process.argv);`
+if (args.includes('-d') || args.includes('--debug')) {
+  process.env.DEBUG_JEN = true;
+}
+
+debug(`Running jen v${pkg.version}`);
+
+jen
+  .version(pkg.version, '-v, --version')
+  .description('Jenkins personal assistant')
+  .option('-d, --debug', 'Enable debug mode');
 
 jen
   .command('init')
@@ -49,7 +60,7 @@ jen
   });
 
 // print usage info if argument is empty.
-if (!process.argv.slice(2).length) {
+if (!args.length) {
   jen.outputHelp();
   process.exit(0);
 }

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,9 +1,7 @@
 const { gray, red } = require('kleur');
 
-const isDebuggingEnabled = process.env.DEBUG_JEN;
-
 function debug(msg) {
-  isDebuggingEnabled && console.log(msg);
+  process.env.DEBUG_JEN && console.log(msg);
 }
 
 function logNetworkErrors(err) {

--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -1,10 +1,14 @@
+const path = require('path');
+
 const Conf = require('conf');
 const { blue, bold, yellow, gray, red, green } = require('kleur');
+
 const { isGitRepository, getGitRootDirPath } = require('../../lib/git-cmd');
 const { printConfig } = require('../../lib/cli-table');
 const { isValidUrl } = require('../../lib/util');
 const { debug } = require('../../lib/log');
 
+// todo: Make store singleton
 const store = new Conf();
 
 function updateStoreWithNewConfiguration(storeKey, oldConfig, updatedConfig) {
@@ -51,7 +55,7 @@ module.exports = async function config(options = {}) {
   if (!store.has(gitRootPath)) {
     console.log(
       yellow(
-        `Config is empty! Introduce jen to your project via ${bold(blue('> jen init'))}`
+        `Config Not Found! Introduce jen to your project via ${bold(blue('> jen init'))}`
       )
     );
     return;
@@ -74,6 +78,7 @@ module.exports = async function config(options = {}) {
   }
 
   // else just print the current config
+  console.log(yellow(`Configuration of ${path.basename(gitRootPath)}`));
   printConfig(oldConfig);
   console.log(gray('Config path - ' + store.path));
 };


### PR DESCRIPTION
- Debugging can be enabled by passing -d or --debug option
  e.g. > jen status -d
- Added debug param usage to the help output
- Display project name in the config output #12

fixes #10 #12 