### PR TITLE
fix: Centralize Jenni command validations

### DIFF
--- a/bin/jen.js
+++ b/bin/jen.js
@@ -1,9 +1,11 @@
 #! /usr/bin/env node
 
 const jen = require('commander');
+
 const pkg = require('../package.json');
-const { init, status, config, open } = require('../src');
+const run = require('../src');
 const { debug } = require('../lib/log');
+const { COMMAND } = require('../config');
 
 const args = process.argv.slice(2);
 
@@ -21,33 +23,30 @@ jen
   .option('-d, --debug', 'Enable debug mode');
 
 jen
-  .command('init')
+  .command(COMMAND.init)
   .description('Initialize jen')
   .action(() => {
-    debug('Executing `init` command');
-    init();
+    run(COMMAND.init);
   });
 
 jen
-  .command('status')
+  .command(COMMAND.status)
   .alias('s')
   .description('Print branch build status')
   .action(() => {
-    debug('Executing `status` command');
-    status();
+    run(COMMAND.status);
   });
 
 jen
-  .command('open')
+  .command(COMMAND.open)
   .alias('o')
   .description('Open jenkins build in browser')
   .action(option => {
-    debug('Executing `open` command');
-    open(option);
+    run(COMMAND.open, option);
   });
 
 jen
-  .command('config')
+  .command(COMMAND.config)
   .alias('c')
   .description('Show repository jen configuration')
   .option('-n, --username <username>', 'Jenkins username')
@@ -55,8 +54,7 @@ jen
   .option('-u, --url <url>', 'Jenkins url')
   .option('-j, --job <job>', 'Current repo base job')
   .action(options => {
-    debug('Executing `config` command');
-    config(options);
+    run(COMMAND.config, options);
   });
 
 // print usage info if argument is empty.

--- a/config/index.js
+++ b/config/index.js
@@ -1,0 +1,6 @@
+exports.COMMAND = {
+  init: 'init',
+  status: 'status',
+  open: 'open',
+  config: 'config',
+};

--- a/lib/cli-table.js
+++ b/lib/cli-table.js
@@ -1,6 +1,8 @@
+const qs = require('querystring');
+
 const Table = require('cli-table');
 const { gray } = require('kleur');
-const qs = require('querystring');
+
 const buildStatus = require('./build-status');
 const { formatTimestampToDate, formatMs } = require('./util');
 

--- a/lib/git-cmd.js
+++ b/lib/git-cmd.js
@@ -1,4 +1,5 @@
 const { spawnSync } = require('child_process');
+
 const { removeNewLine } = require('./util');
 
 exports.getCurrentBranchName = function() {

--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -1,6 +1,7 @@
 const Conf = require('conf');
 const got = require('got');
 const cheerio = require('cheerio');
+
 const { extractSchemeFromUrl, extractUrlWithoutScheme } = require('./util');
 const { getGitRootDirPath } = require('./git-cmd');
 

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,17 +1,17 @@
-const { gray, red } = require('kleur');
+const { red } = require('kleur');
 
 function debug(msg) {
   process.env.DEBUG_JEN && console.log(msg);
 }
 
-function logNetworkErrors(err) {
+function logNetworkErrors(err = {}) {
   if (err.code === 'ETIMEDOUT') {
     console.log(red('Request timeout error!'));
     debug(err);
     return;
   }
 
-  console.log('\n' + gray(err.statusMessage || err.name));
+  console.log(red(err.statusMessage || err.name));
   debug(err);
 }
 

--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -1,14 +1,13 @@
 const path = require('path');
 
 const Conf = require('conf');
-const { blue, bold, yellow, gray, red, green } = require('kleur');
+const { yellow, gray, red, green } = require('kleur');
 
-const { isGitRepository, getGitRootDirPath } = require('../../lib/git-cmd');
+const { getGitRootDirPath } = require('../../lib/git-cmd');
 const { printConfig } = require('../../lib/cli-table');
 const { isValidUrl } = require('../../lib/util');
 const { debug } = require('../../lib/log');
 
-// todo: Make store singleton
 const store = new Conf();
 
 function updateStoreWithNewConfiguration(storeKey, oldConfig, updatedConfig) {
@@ -42,25 +41,7 @@ function updateStoreWithNewConfiguration(storeKey, oldConfig, updatedConfig) {
 }
 
 module.exports = async function config(options = {}) {
-  // not a git repository
-  if (!isGitRepository()) {
-    console.log(
-      yellow('jen has no power here! Please execute jen commands inside the git dir.')
-    );
-    process.exit();
-  }
-
   const gitRootPath = getGitRootDirPath();
-
-  if (!store.has(gitRootPath)) {
-    console.log(
-      yellow(
-        `Config Not Found! Introduce jen to your project via ${bold(blue('> jen init'))}`
-      )
-    );
-    return;
-  }
-
   const oldConfig = store.get(gitRootPath);
   const { username, token, url, job } = options;
   const updatedConfig = {

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -1,0 +1,8 @@
+const { COMMAND } = require('../../config');
+
+module.exports = {
+  [COMMAND.init]: require('./init'),
+  [COMMAND.status]: require('./status'),
+  [COMMAND.config]: require('./config'),
+  [COMMAND.open]: require('./open'),
+};

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -1,20 +1,13 @@
 const Conf = require('conf');
-const { isGitRepository, getGitRootDirPath } = require('../../lib/git-cmd');
-const { yellow, green, gray } = require('kleur');
+const { green, gray } = require('kleur');
+
+const { getGitRootDirPath } = require('../../lib/git-cmd');
 const { requestJenkinsCredentials, askConfirmation } = require('../../lib/prompt');
 const { printConfig } = require('../../lib/cli-table');
 
 const store = new Conf();
 
 module.exports = async function init() {
-  // not a git repository
-  if (!isGitRepository()) {
-    console.log(
-      yellow('jen has no power here! Please execute jen commands inside the git dir.')
-    );
-    process.exit();
-  }
-
   const res = await requestJenkinsCredentials();
 
   // 3 fields are required
@@ -26,5 +19,9 @@ module.exports = async function init() {
       store.set(getGitRootDirPath(), res);
       console.log(green('Configuration successfully saved at ') + gray(store.path));
     }
+
+    // todo: Display a message when confirmation rejected
   }
+
+  // todo: Display a message when required fields are missing
 };

--- a/src/commands/open.js
+++ b/src/commands/open.js
@@ -1,37 +1,10 @@
 const _open = require('open');
-const { yellow, bold, blue } = require('kleur');
-const Conf = require('conf');
-const {
-  isGitRepository,
-  getGitRootDirPath,
-  getCurrentBranchName,
-} = require('../../lib/git-cmd');
+
+const { getCurrentBranchName } = require('../../lib/git-cmd');
 const { getBranchJobLink } = require('../../lib/jenkins');
 const { debug } = require('../../lib/log');
 
-const store = new Conf();
-
 module.exports = function open(buildNumber = null) {
-  // not a git repository
-  if (!isGitRepository()) {
-    console.log(
-      yellow('jen has no power here! Please execute jen commands inside the git dir.')
-    );
-    process.exit();
-  }
-
-  // if we couldn't find the config then jen not yet initialized
-  if (!store.get(getGitRootDirPath())) {
-    console.log(
-      yellow(
-        `Could not find the config! Introduce jen to your project via ${bold(
-          blue('> jen init')
-        )}`
-      )
-    );
-    process.exit();
-  }
-
   const branchName = getCurrentBranchName();
   let url = getBranchJobLink(branchName);
 

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -1,42 +1,17 @@
-const Conf = require('conf');
 const ora = require('ora');
-const { yellow, bold, blue, gray } = require('kleur');
+const { yellow, gray, red } = require('kleur');
 const terminalLink = require('terminal-link');
-const {
-  getCurrentBranchName,
-  isGitRepository,
-  getGitRootDirPath,
-} = require('../../lib/git-cmd');
+
+const { getCurrentBranchName } = require('../../lib/git-cmd');
 const { getBranchBuildHistory, getBranchJobLink } = require('../../lib/jenkins');
 const { printBuildHistory } = require('../../lib/cli-table');
 const { logNetworkErrors, debug } = require('../../lib/log');
 
 const spinner = ora();
-const store = new Conf();
 
 module.exports = async function showBuildStatus() {
-  // not a git repository
-  if (!isGitRepository()) {
-    console.log(
-      yellow('jen has no power here! Please execute jen commands inside the git dir.')
-    );
-    process.exit();
-  }
-
-  // if we couldn't find the config then jen not yet initialized
-  if (!store.get(getGitRootDirPath())) {
-    console.log(
-      yellow(
-        `Could not find the config! Introduce jen to your project via ${bold(
-          blue('> jen init')
-        )}`
-      )
-    );
-    process.exit();
-  }
-
   const branchName = getCurrentBranchName();
-  debug(`Branch name is: ${branchName}`);
+  debug(`Branch name: ${branchName}`);
 
   try {
     spinner.start();
@@ -56,6 +31,15 @@ module.exports = async function showBuildStatus() {
     console.log(`${gray('Last ' + builds.length + ' build results.')}`);
   } catch (err) {
     spinner.stop();
+
+    if (err.statusCode === 404) {
+      console.log(
+        `${red('Job not found')} - Jenkins job does not exist for branch "${branchName}"`
+      );
+      debug(err);
+      process.exit();
+    }
+
     logNetworkErrors(err);
     process.exit();
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,34 @@
-exports.init = require('./commands/init');
-exports.status = require('./commands/status');
-exports.config = require('./commands/config');
-exports.open = require('./commands/open');
+const Conf = require('conf');
+const { yellow, blue, bold } = require('kleur');
+
+const { isGitRepository, getGitRootDirPath } = require('../lib/git-cmd');
+const { COMMAND } = require('../config');
+const { debug } = require('../lib/log');
+const commands = require('./commands');
+
+const store = new Conf();
+
+module.exports = function run(cmd, options) {
+  // not a git repository
+  if (!isGitRepository()) {
+    console.log(
+      yellow('jen has no power here! Please execute jen commands inside the git dir.')
+    );
+    process.exit();
+  }
+
+  // for other than `init` cmd make sure jen is initialized
+  if (cmd !== COMMAND.init && !store.has(getGitRootDirPath())) {
+    console.log(
+      yellow(
+        `Could not find the config! Introduce jen to your project via ${bold(
+          blue('> jen init')
+        )}`
+      )
+    );
+    process.exit();
+  }
+
+  debug(`Executing \`${cmd}\` command`);
+  commands[cmd](options);
+};


### PR DESCRIPTION
* Added a wrapper function to centralize command invocation. Which is responsible to execute all Jenni commands. Logics that are common to commands can be implemented here. e.g (validations)
* More descriptive error message when build not found (#21)

Closes #26 #21