### PR TITLE
feat: Delete the configuration file when uninstalling the package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:watch": "jest --watch",
     "lint": "eslint '**/*.js'",
     "lint-fix": "eslint --fix",
-    "prettier": "prettier --config ./prettier.config.js --write"
+    "prettier": "prettier --config ./prettier.config.js --write",
+    "preuninstall": "node src/scripts/pre-uninstall.js"
   },
   "husky": {
     "hooks": {
@@ -35,6 +36,7 @@
     "cli-app",
     "cli",
     "jenkins-cli",
+    "jenkins",
     "nodejs"
   ],
   "author": "Sureshraj <m.s.suresh100@gmail.com>",

--- a/src/scripts/pre-uninstall.js
+++ b/src/scripts/pre-uninstall.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
+const Conf = require('conf');
+const { red, yellow } = require('kleur');
+
+// Initializing `new Conf()` will create a empty directory.
+const store = new Conf();
+const configFilePath = store.path;
+const configDirPath = path.dirname(configFilePath);
+
+function removeConfigDir() {
+  try {
+    if (fs.existsSync(configFilePath)) fs.unlinkSync(configFilePath);
+
+    fs.rmdirSync(configDirPath);
+  } catch (err) {
+    console.log(red('Failed to remove local configuration file.'));
+    console.log(`Delete the following directory ${yellow(configDirPath)}`);
+  }
+}
+
+if (require.main === module) {
+  // execute the fn only if script called from the command line. e.g. node <path/to/file>
+  removeConfigDir();
+} else {
+  // for testing purpose export the fn
+  module.exports = removeConfigDir;
+}

--- a/src/scripts/pre-uninstall.spec.js
+++ b/src/scripts/pre-uninstall.spec.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+
+const Conf = require('conf');
+const { red, yellow } = require('kleur');
+
+jest.mock('fs');
+jest.mock('conf');
+
+const fakePath = 'some/fake/path';
+// mock Conf constructor fn
+Conf.mockImplementation(() => {
+  return {
+    path: fakePath,
+  };
+});
+
+const removeConfigDir = require('./pre-uninstall');
+
+describe('pre-uninstall', () => {
+  beforeEach(() => {
+    fs.unlinkSync.mockClear();
+    fs.rmdirSync.mockClear();
+  });
+
+  it('should delete the configuration file and the directory', () => {
+    fs.existsSync = jest.fn(() => true);
+    removeConfigDir();
+
+    expect(fs.unlinkSync).toHaveBeenCalledWith(fakePath);
+    expect(fs.rmdirSync).toHaveBeenCalledWith('some/fake');
+  });
+
+  it('should only delete the configuration directory if there is no configuration file', () => {
+    fs.existsSync = jest.fn(() => false);
+    removeConfigDir();
+
+    expect(fs.unlinkSync).not.toHaveBeenCalled();
+    expect(fs.rmdirSync).toHaveBeenCalledWith('some/fake');
+  });
+
+  it("should log the message if it couldn't delete the configuration file or directory", () => {
+    const spy = jest.spyOn(global.console, 'log').mockImplementation();
+    fs.existsSync = jest.fn().mockImplementation(() => {
+      throw new Error('some error');
+    });
+    removeConfigDir();
+
+    expect(console.log).toHaveBeenCalledTimes(2);
+    expect(console.log.mock.calls[0][0]).toBe(
+      red('Failed to remove local configuration file.')
+    );
+    expect(console.log.mock.calls[1][0]).toBe(
+      `Delete the following directory ${yellow('some/fake')}`
+    );
+
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
feat: Delete the configuration file when uninstalling the package.

* Implemented configuration delete functionality through NPM `preuninstall` script.
* Added unit tests for pre uninstall script

closes #11 