### PR TITLE
fix: Fixed broken "jen config" command

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,8 @@ module.exports = {
   plugins: ['prettier', 'jest'],
   // 0: off, 1: warn, 2: error
   rules: {
-    'prettier/prettier': 'error',
-    'no-console': 'off',
+    'prettier/prettier': 2,
+    'no-console': 0,
+    'prefer-template': 2,
   },
 };

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Commands:
   status|s            Print branch build status
   open|o              Open jenkins build in browser
   build|b             Trigger a new build
-  config|c [options]  Show repository jen configuration
+  config|c [options]  Show or Update repository configuration
 ```
 
 | Command | Options | Description |
@@ -62,7 +62,7 @@ Commands:
 | `jen status` \| `s` | - | Print branch build history |
 | `jen open` \| `o` | Optional build number <br><br> e.g. `jen open <build number>` | Open jenkins build in browser |
 | `jen build` \| `b` | - | Trigger a new build |
-| `jen config` \| `c` | `--username` \| `-n` <br> `--token` \| `-t`  <br> `--url` \| `-u` <br> `--job` \| `-j` <br> <br> e.g. Reconfigure username & token <br> `jen config --username <foo> --token <bar>` | Overwrite project jenni config. Without any options it will print current config. |
+| `jen config` \| `c` | `--username` \| `-n` <br> `--token` \| `-t`  <br> `--url` \| `-u` <br> `--job-name` <br> `--job-path` <br> `--job-type` <br> <br> e.g. Reconfigure username & token <br> `jen config --username <foo> --token <bar>` | Overwrite project jenni config. Without any options it will print current config. |
 
 ## Debug
 It's basic for the moment, pass `-d` or `--debug` to log debug messages. Can also be enabled by setting the environment variable `DEBUG_JEN` to `true`. E.g.

--- a/src/bin/jen.js
+++ b/src/bin/jen.js
@@ -57,11 +57,13 @@ jen
 jen
   .command(COMMAND.config)
   .alias('c')
-  .description('Show repository jen configuration')
+  .description('Show or Update repository configuration')
   .option('-n, --username <username>', 'Jenkins username')
   .option('-t, --token <token>', 'Jenkins api-token')
-  .option('-u, --url <url>', 'Jenkins url')
-  .option('-j, --job <job>', 'Current repo base job')
+  .option('-u, --url <url>', 'Jenkins base URL')
+  .option('--job-name <jobname>', 'Job name')
+  .option('--job-path <jobpath>', 'Job path')
+  .option('--job-type <jobtype>', 'Job type')
   .action(options => {
     run(COMMAND.config, options);
   });

--- a/src/commands/__tests__/config.spec.js
+++ b/src/commands/__tests__/config.spec.js
@@ -1,0 +1,99 @@
+const path = require('path');
+
+const Conf = require('conf');
+const { yellow, green } = require('kleur');
+
+const { getGitRootDirPath } = require('../../lib/git-cmd');
+const { printConfig } = require('../../lib/cli-table');
+const config = require('../config');
+
+jest.mock('../../lib/git-cmd');
+jest.mock('../../lib/cli-table');
+jest.mock('conf');
+
+const gitRootDirPath = 'some/path/to/git';
+const oldConfig = {
+  username: 'bingo',
+  token: 'abc468&*&$$--rtu',
+  url: 'http://localhost:3000',
+  job: {
+    name: 'foo',
+    path: '/some/path',
+    type: 'jobType',
+  },
+};
+
+beforeAll(() => {
+  getGitRootDirPath.mockImplementation(() => gitRootDirPath);
+
+  const projectConfig = new Map();
+  projectConfig.set(gitRootDirPath, oldConfig);
+
+  Conf.prototype.get.mockImplementation(key => projectConfig.get(key));
+  jest.spyOn(global.console, 'log').mockImplementation();
+  jest.spyOn(process, 'exit').mockImplementation();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('config', () => {
+  it('should print the old config if updated config argument is empty', () => {
+    config();
+
+    expect(console.log).toHaveBeenCalledTimes(2);
+    expect(console.log.mock.calls[0][0]).toBe(
+      yellow(`Configuration of ${path.basename(gitRootDirPath)}`)
+    );
+    expect(printConfig).toHaveBeenCalledWith(oldConfig);
+  });
+
+  it('should update the old configuration', () => {
+    const updatedConfig = {
+      username: 'bar',
+      jobName: 'car',
+      jobPath: '/some/path',
+      jobType: 'bingo',
+    };
+    config(updatedConfig);
+
+    const mergedConfig = {
+      ...oldConfig,
+      username: updatedConfig.username,
+      job: {
+        name: updatedConfig.jobName,
+        type: updatedConfig.jobType,
+        path: updatedConfig.jobPath,
+      },
+    };
+
+    expect(Conf.prototype.set).toHaveBeenCalledWith(gitRootDirPath, mergedConfig);
+    expect(console.log.mock.calls[0][0]).toBe(
+      green('Configuration successfully updated')
+    );
+    expect(printConfig).toHaveBeenCalledWith(mergedConfig);
+  });
+
+  it('should throw an error if updated config values are invalid', () => {
+    const updatedConfigOne = {
+      url: 'invalid url',
+    };
+    config(updatedConfigOne);
+
+    expect(console.log.mock.calls[0][0]).toBe(`Invalid URL: ${updatedConfigOne.url}`);
+    expect(process.exit).toHaveBeenCalled();
+
+    jest.clearAllMocks();
+
+    const updatedConfigTwo = {
+      jobName: '  ',
+    };
+    config(updatedConfigTwo);
+
+    expect(console.log.mock.calls[0][0]).toBe(
+      `Argument "${yellow('name')}" value is invalid ${updatedConfigTwo.jobName}`
+    );
+    expect(process.exit).toHaveBeenCalled();
+  });
+});

--- a/src/commands/open.js
+++ b/src/commands/open.js
@@ -10,9 +10,9 @@ module.exports = function open(buildNumber = null) {
 
   // if the argument is empty, commander will pass the default options object
   if (buildNumber && typeof buildNumber !== 'object') {
-    url += '/' + buildNumber;
+    url += `/${buildNumber}`;
   }
 
-  debug('Opening - ' + url);
+  debug(`Opening - ${url}`);
   _open(url);
 };

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -25,7 +25,7 @@ module.exports = async function showBuildStatus() {
     spinner.stop();
 
     // title
-    console.log(yellow('Build history of - ' + terminalLink(jobTitle, jobLink)));
+    console.log(yellow(`Build history of - ${terminalLink(jobTitle, jobLink)}`));
 
     if (!builds.length) {
       console.log(gray('No build exists for this branch!'));
@@ -33,7 +33,7 @@ module.exports = async function showBuildStatus() {
     }
 
     printBuildHistory(builds);
-    console.log(`${gray('Last ' + builds.length + ' build results.')}`);
+    console.log(`${gray(`Last ${builds.length} build results.`)}`);
   } catch (err) {
     spinner.stop();
 

--- a/src/lib/jenkins.js
+++ b/src/lib/jenkins.js
@@ -108,7 +108,7 @@ function getRunningBuildsRemainingTime(branchName, buildId) {
   // this api will return build history as a html response
   // with the `n` header we can control the results limit [n, ..., n + 1]
   // e.g. if the `buildId` is 520 then it will return all the build history from 520 to upwards
-  const url = getJobUrl(branchName) + '/buildHistory/ajax';
+  const url = `${getJobUrl(branchName)}/buildHistory/ajax`;
 
   return client
     .post(url, { headers: { n: buildId } })
@@ -226,7 +226,7 @@ exports.constructJobTitle = function(branchName = '') {
 
 exports.triggerNewBuild = function(branchName) {
   // `?delay=0sec` to instantly trigger the build
-  const jobUrl = getJobUrl(branchName) + '/build?delay=0sec';
+  const jobUrl = `${getJobUrl(branchName)}/build?delay=0sec`;
   debug(`Triggering a build for: ${jobUrl}`);
 
   return client.post(jobUrl);

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -59,9 +59,9 @@ exports.formatMs = function(ms) {
   const hours = Math.floor(ms / (1000 * 60 * 60));
   const formattedTime = [];
 
-  if (hours) formattedTime.push(hours.toString(10).padStart(2, '0') + ' hrs');
-  if (minutes) formattedTime.push(minutes.toString(10).padStart(2, '0') + ' min');
-  if (seconds) formattedTime.push(seconds.toString(10).padStart(2, '0') + ' sec');
+  if (hours) formattedTime.push(`${hours.toString(10).padStart(2, '0')} hrs`);
+  if (minutes) formattedTime.push(`${minutes.toString(10).padStart(2, '0')} min`);
+  if (seconds) formattedTime.push(`${seconds.toString(10).padStart(2, '0')} sec`);
 
   return formattedTime.join(', ');
 };


### PR DESCRIPTION
fix: Fixed broken `jen config` command

* Introduced new config options to update job name, path, and type
* Added unit tests for "jen config" command
* Enabled `prefer-template` option in eslint
* Replaced string concatenation with a template string

closes #37