### PR TITLE
feat(build-cmd): Option to follow the build progress after triggering a build

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Note - jenni will only work inside the **git** repository
 ## Features
 * Print Jenkins build history of a Job.
 * Show estimated remaining time for running builds.
-* Open Jenkins build in browser.
-* Trigger new builds (without parameters)
+* Open Jenkins build in the browser.
+* Trigger new builds. (without parameters)
+* Watch the console output after triggering a build.
 
 ## Upcoming Features
 * Trigger new builds with parameters
@@ -68,16 +69,16 @@ Commands:
   init|i              Initialize jen
   status|s            Print branch build status
   open|o              Open jenkins build in browser
-  build|b             Trigger a new build
+  build|b [options]   Trigger a new build
   config|c [options]  Show or Update repository configuration
 ```
 
 | Command&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Options | Description |
 | --- | --- | --- |
-| `jen init` \| `i` | - | Initialize jenni to your project |
-| `jen status` \| `s` | - | Print branch build history |
-| `jen open` \| `o` | Optional build number <br> e.g. `jen open <build number>` | Open jenkins build in browser |
-| `jen build` \| `b` | - | Trigger a new build |
+| `jen init` \| `i` | - | Initialize jenni to your project. |
+| `jen status` \| `s` | - | Print branch build history. |
+| `jen open` \| `o` | Optional build number <br> e.g. `jen open <build number>` | Open jenkins build in the browser. |
+| `jen build` \| `b` | `--watch` \| `-w` <br> <br> Use this option to watch the console output after triggering a build. | Trigger a new build. |
 | `jen config` \| `c` | `--username` \| `-n` <br> `--token` \| `-t`  <br> `--url` \| `-u` <br> `--job-name` <br> `--job-path` <br> `--job-type` <br> <br> e.g. Reconfigure username & token <br> `jen config --username <foo> --token <bar>` | Overwrite project jenni config. Without any options it will print current config. |
 
 ## Debug

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged",
-      "pre-push": "npm test"
+      "pre-commit": "lint-staged"
     }
   },
   "lint-staged": {

--- a/src/bin/jen.js
+++ b/src/bin/jen.js
@@ -49,9 +49,10 @@ jen
 jen
   .command(COMMAND.build)
   .alias('b')
+  .option('-w, --watch', 'Watch build console output')
   .description('Trigger a new build')
-  .action(() => {
-    run(COMMAND.build);
+  .action(option => {
+    run(COMMAND.build, option);
   });
 
 jen

--- a/src/commands/__tests__/build.spec.js
+++ b/src/commands/__tests__/build.spec.js
@@ -1,7 +1,14 @@
+const EventEmitter = require('events');
+
 const { red } = require('kleur');
 
 const { getCurrentBranchName } = require('../../lib/git-cmd');
-const { triggerNewBuild, getRunningBuilds } = require('../../lib/jenkins');
+const {
+  triggerNewBuild,
+  getRunningBuilds,
+  getQueueItem,
+  createProgressiveTextStream,
+} = require('../../lib/jenkins');
 const { logNetworkErrors } = require('../../lib/log');
 const { askConfirmationBeforeTriggeringNewBuild } = require('../../lib/prompt');
 
@@ -24,13 +31,27 @@ const build = require('../build');
 
 describe('build', () => {
   const branchName = 'foo';
+  let spiedStdWrite;
   beforeAll(() => {
     getCurrentBranchName.mockImplementation(() => branchName);
+    spiedStdWrite = jest.spyOn(process.stdout, 'write').mockImplementation();
+  });
+
+  afterAll(() => {
+    spiedStdWrite.mockRestore();
   });
 
   beforeEach(() => {
     getRunningBuilds.mockImplementation(() =>
       Promise.resolve(['some', 'running', 'builds'])
+    );
+
+    triggerNewBuild.mockImplementation(() =>
+      Promise.resolve({
+        headers: {
+          location: 'http://localhost:8080/queue/item/100',
+        },
+      })
     );
   });
 
@@ -49,7 +70,7 @@ describe('build', () => {
     expect(spinner.succeed).toHaveBeenCalledWith('Build successfully created');
   });
 
-  it('should ask confirmation when job has already running builds', async () => {
+  it('should ask confirmation when the job has running builds', async () => {
     await build();
 
     expect(spinner.stop).toHaveBeenCalled();
@@ -81,13 +102,78 @@ describe('build', () => {
     expect(process.exit).toHaveBeenCalledTimes(1);
   });
 
-  it('should log the error messages when triggering new build fails', async () => {
+  it('should handle the exception when it fails to trigger a build', async () => {
     const error = 'some error';
     getRunningBuilds.mockImplementation(() => Promise.reject(error));
 
     await build();
 
-    expect(spinner.fail).toHaveBeenCalled();
+    expect(spinner.fail).toHaveBeenCalledWith('Failed to create the build');
     expect(logNetworkErrors).toHaveBeenCalledWith(error);
+  });
+
+  describe('report build progress', () => {
+    const options = { watch: true };
+    const buildId = 200;
+
+    beforeEach(() => {
+      getRunningBuilds.mockImplementation(() => Promise.resolve([]));
+
+      getQueueItem.mockImplementation(() =>
+        Promise.resolve({
+          executable: {
+            number: buildId,
+          },
+        })
+      );
+    });
+
+    it('should handle the exception when it fails to report the build progress', async () => {
+      getQueueItem.mockImplementation(() => Promise.reject('failed'));
+
+      await build(options);
+
+      expect(getQueueItem).toHaveBeenCalledWith('100', true);
+      expect(spinner.fail).toHaveBeenCalledWith(
+        'An error occurred while retrieving in progress build console'
+      );
+    });
+
+    it('should report when the queued job gets cancelled', async () => {
+      getQueueItem.mockImplementationOnce(() =>
+        Promise.resolve({
+          cancelled: true,
+        })
+      );
+
+      await build(options);
+
+      expect(spinner.fail).toHaveBeenCalledWith(
+        'Build has been cancelled. Unable to report the build progress.'
+      );
+    });
+
+    it('should report the build progress', async () => {
+      const emitter = new EventEmitter();
+      createProgressiveTextStream.mockImplementation(() => emitter);
+
+      await build(options);
+
+      expect(createProgressiveTextStream).toHaveBeenCalledWith(branchName, buildId);
+      expect(emitter.eventNames()).toEqual(['data', 'end', 'error']);
+    });
+
+    it('should handle any exceptions while retrieving in progress build console', async () => {
+      const emitter = new EventEmitter();
+      createProgressiveTextStream.mockImplementation(() => emitter);
+
+      await build(options);
+
+      emitter.emit('error', new Error('boom!'));
+
+      expect(spinner.fail).toHaveBeenCalledWith(
+        'An error occurred while retrieving in progress build console'
+      );
+    });
   });
 });

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -3,12 +3,66 @@ const { red } = require('kleur');
 
 const { getCurrentBranchName } = require('../lib/git-cmd');
 const { logNetworkErrors, debug } = require('../lib/log');
-const { triggerNewBuild, getRunningBuilds } = require('../lib/jenkins');
+const {
+  triggerNewBuild,
+  getRunningBuilds,
+  createProgressiveTextStream,
+  getQueueItem,
+} = require('../lib/jenkins');
 const { askConfirmationBeforeTriggeringNewBuild } = require('../lib/prompt');
+const { WatchError, ERROR_TYPE } = require('../lib/errors');
 
 const spinner = ora();
 
-module.exports = async function build() {
+// http://localhost:8080/queue/item/11/ => 11
+function extractQueueItemNumber(queueUrl = '') {
+  return queueUrl
+    .split('/')
+    .filter(Boolean)
+    .pop();
+}
+
+async function reportBuildProgress(branchName, queuedItemNumber) {
+  try {
+    const retryUntilBuildFound = true;
+    const queueItem = await getQueueItem(queuedItemNumber, retryUntilBuildFound);
+
+    if (queueItem.cancelled) {
+      throw new WatchError(
+        'Build has been cancelled. Unable to report the build progress.'
+      );
+    }
+
+    // we can safely access the `executable` because `getQueueItem` retry until `executable` found
+    const buildId = queueItem.executable.number;
+    const stream = createProgressiveTextStream(branchName, buildId);
+
+    stream.on('data', data => {
+      spinner.stop();
+      process.stdout.write(data);
+      spinner.start();
+    });
+
+    stream.on('end', () => {
+      spinner.stop();
+    });
+
+    stream.on('error', error => {
+      process.stdout.write('\n');
+      spinner.fail('An error occurred while retrieving in progress build console');
+      debug(error);
+    });
+  } catch (error) {
+    if (error.name === ERROR_TYPE.watchError) throw error;
+
+    throw new WatchError(
+      'An error occurred while retrieving in progress build console',
+      error
+    );
+  }
+}
+
+module.exports = async function build(options = {}) {
   const branchName = getCurrentBranchName();
   debug(`Branch name: ${branchName}`);
 
@@ -28,10 +82,23 @@ module.exports = async function build() {
       spinner.start();
     }
 
-    await triggerNewBuild(branchName);
+    const { headers } = await triggerNewBuild(branchName);
     spinner.succeed('Build successfully created');
-  } catch (err) {
+
+    if (options.watch) {
+      debug('Watch option enabled. Retrieving in progress build console');
+      process.stdout.write('\n');
+      await reportBuildProgress(branchName, extractQueueItemNumber(headers.location));
+    }
+  } catch (error) {
+    if (error.name === ERROR_TYPE.watchError) {
+      process.stdout.write('\n');
+      spinner.fail(error.message);
+      debug(error);
+      return;
+    }
+
     spinner.fail('Failed to create the build');
-    logNetworkErrors(err);
+    logNetworkErrors(error);
   }
 };

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -1,0 +1,40 @@
+const ERROR_TYPE = {
+  watchError: 'WatchError',
+};
+
+class WatchError extends Error {
+  constructor(message, error = {}) {
+    super(message);
+    Error.captureStackTrace(this, this.constructor);
+
+    this.name = ERROR_TYPE.watchError;
+
+    // Following stacktrace manipulation logic copied from https://github.com/sindresorhus/got/blob/master/source/core/index.ts#L392
+    // Recover the original stacktrace
+    if (typeof error.stack !== 'undefined') {
+      const indexOfMessage = this.stack.indexOf(this.message) + this.message.length;
+      const thisStackTrace = this.stack
+        .slice(indexOfMessage)
+        .split('\n')
+        .reverse();
+      const errorStackTrace = error.stack
+        .slice(error.stack.indexOf(error.message) + error.message.length)
+        .split('\n')
+        .reverse();
+
+      // Remove duplicated traces
+      while (errorStackTrace.length !== 0 && errorStackTrace[0] === thisStackTrace[0]) {
+        thisStackTrace.shift();
+      }
+
+      this.stack = `${this.stack.slice(0, indexOfMessage)}${thisStackTrace
+        .reverse()
+        .join('\n')}${errorStackTrace.reverse().join('\n')}`;
+    }
+  }
+}
+
+module.exports = {
+  WatchError,
+  ERROR_TYPE,
+};

--- a/src/lib/jenkins.js
+++ b/src/lib/jenkins.js
@@ -7,6 +7,7 @@ const cheerio = require('cheerio');
 const { getGitRootDirPath } = require('./git-cmd');
 const { JOB_TYPE } = require('../config');
 const { debug } = require('./log');
+const StreamProgressiveText = require('./stream-progressive-text');
 
 const store = new Conf();
 const client = got.extend({ timeout: 3000 });
@@ -236,4 +237,65 @@ exports.getRunningBuilds = async function(branchName) {
   const builds = await getBuilds(branchName);
 
   return filterRunningBuilds(builds);
+};
+
+exports.createProgressiveTextStream = function(branchName, buildId) {
+  if (!buildId) throw Error('Invalid build id');
+
+  const url = `${getJobUrl(branchName)}/${buildId}/logText/progressiveText`;
+
+  return new StreamProgressiveText(url);
+};
+
+/* Notes related to queue (https://stackoverflow.com/a/45514691/2967670)
+ * If a build has not yet started, the build information will be blank.
+ * Once a build has started, Jenkins will remove the queue item after 5 minutes. */
+exports.getQueueItem = async function(itemNumber, retryUntilBuildFound = false) {
+  if (!itemNumber) throw Error('Invalid queue item number');
+
+  const url = `${getBaseUrl()}/queue/item/${itemNumber}/api/json`;
+  const { body } = await client.get(url, { json: true });
+
+  if (body.executable || !retryUntilBuildFound) {
+    return body;
+  }
+
+  debug(
+    'Unable to find the build information from the queue item on the initial attempt'
+  );
+  const retryDelayInMs = 1000;
+  const maximumRetryAttempts = 3;
+  let attempts = 0;
+
+  return new Promise((resolve, reject) => {
+    function _getQueueItem() {
+      attempts++;
+      debug(`getQueueItem attempt: ${attempts}`);
+
+      client
+        .get(url, { json: true })
+        .then(({ body }) => {
+          if (body.executable) return resolve(body);
+
+          if (attempts > maximumRetryAttempts) {
+            return reject(
+              'Maximum retry attempts reached. Unable to find the build information from the queue item'
+            );
+          }
+
+          setTimeout(() => {
+            debug(
+              `Scheduling an event to retrieve queue item after: ${retryDelayInMs *
+                attempts} ms`
+            );
+            _getQueueItem();
+          }, retryDelayInMs * attempts);
+        })
+        .catch(error => {
+          reject(error);
+        });
+    }
+
+    return _getQueueItem();
+  });
 };

--- a/src/lib/message.js
+++ b/src/lib/message.js
@@ -1,1 +1,0 @@
-// todo - generalize common console message

--- a/src/lib/stream-progressive-text.js
+++ b/src/lib/stream-progressive-text.js
@@ -1,0 +1,42 @@
+const EventEmitter = require('events');
+
+const got = require('got');
+
+const client = got.extend({ timeout: 3000 });
+
+class StreamProgressiveText extends EventEmitter {
+  constructor(url) {
+    super();
+    this.url = url;
+    const initialOffset = 0;
+
+    process.nextTick(async () => {
+      await this.fetchConsoleTextProgressively(initialOffset);
+    });
+  }
+
+  async fetchConsoleTextProgressively(offset) {
+    try {
+      const {
+        body,
+        headers: { 'x-text-size': size, 'x-more-data': more },
+      } = await client.get(`${this.url}?start=${offset}`);
+
+      if (typeof body === 'string' && body.length) {
+        this.emit('data', body);
+      }
+
+      if (more === 'true') {
+        setTimeout(() => {
+          this.fetchConsoleTextProgressively(size);
+        }, 1000);
+      } else {
+        this.emit('end');
+      }
+    } catch (error) {
+      this.emit('error', error);
+    }
+  }
+}
+
+module.exports = StreamProgressiveText;


### PR DESCRIPTION
The `Jen build (alias b)` command now takes an argument `--watch (alias -w)` to progressively report the build progress after triggering a build.

closes #44 