### PR TITLE
feat: Handle `OrganizationFolder` type jobs when initializing Jenni

### DIFF
--- a/src/lib/__tests__/jenkins.spec.js
+++ b/src/lib/__tests__/jenkins.spec.js
@@ -97,6 +97,30 @@ describe('getJobs', () => {
       ],
     },
     {
+      _class: 'jenkins.branch.OrganizationFolder',
+      displayName: 'org-folder-display-name',
+      name: 'organization-folder',
+      url: 'http://localhost:8080/job/organization-folder/',
+      jobs: [
+        {
+          _class: 'org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject',
+          displayName: 'sample_project_for_jenni',
+          name: 'sample_project_for_jenni',
+          url:
+            'http://localhost:8080/job/organization-folder/job/sample_project_for_jenni/',
+          jobs: [
+            {
+              _class: 'org.jenkinsci.plugins.workflow.job.WorkflowJob',
+              displayName: 'master',
+              name: 'master',
+              url:
+                'http://localhost:8080/job/organization-folder/job/sample_project_for_jenni/job/master/',
+            },
+          ],
+        },
+      ],
+    },
+    {
       name: 'Github type jenkins project',
       url: 'http://localhost:8080/job/Github%20type%20jenkins%20project/',
       _class: 'org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject',
@@ -144,6 +168,12 @@ describe('getJobs', () => {
         type: 'WorkflowMultiBranchProject',
       },
       {
+        name: 'org-folder-display-name → sample_project_for_jenni',
+        url:
+          'http://localhost:8080/job/organization-folder/job/sample_project_for_jenni/',
+        type: 'WorkflowMultiBranchProject',
+      },
+      {
         name: 'sample folder → one more folder → nested',
         url:
           'http://localhost:8080/job/folder%20project/job/one%20more%20folder/job/nested/',
@@ -151,7 +181,7 @@ describe('getJobs', () => {
       },
     ];
 
-    expect(jobs).toEqual(expectedResult);
+    expect(jobs).toStrictEqual(expectedResult);
   });
 
   it('should throw an error when request fails', async () => {

--- a/src/lib/jenkins.js
+++ b/src/lib/jenkins.js
@@ -122,26 +122,28 @@ function extractJobType(str = '') {
   return str.split('.').pop();
 }
 
-function flattenNestedJobs(jobs) {
+function flattenNestedJobs(nestedJobs) {
   function mapJobs(job) {
     return {
       ...job,
-      displayName: `${this.folderName} → ${job.displayName || job.name}`,
+      displayName: `${this.parentName} → ${job.displayName || job.name}`,
     };
   }
 
+  const jobs = [...nestedJobs]; // to avoid mutating the argument
   const transformedJobs = [];
   let job;
   let jobType = '';
+
   while (jobs.length) {
     job = jobs.shift();
     job.displayName = job.displayName || job.name;
     jobType = extractJobType(job._class);
 
-    if (jobType === 'Folder') {
+    if (jobType === 'Folder' || jobType === 'OrganizationFolder') {
       jobs.push(
         ...job.jobs.map(mapJobs, {
-          folderName: job.displayName,
+          parentName: job.displayName,
         })
       );
     } else {


### PR DESCRIPTION
When initializing Jenni, it will display jobs that are inside the `OrganizationFolder` as well.

closes: #61