### PR TITLE
feat: Support branch name with slashes

### DIFF
--- a/src/lib/__tests__/git-cmd.spec.js
+++ b/src/lib/__tests__/git-cmd.spec.js
@@ -1,0 +1,89 @@
+const { spawnSync } = require('child_process');
+
+const {
+  getCurrentBranchName,
+  isGitRepository,
+  getGitRootDirPath,
+} = require('../git-cmd');
+
+jest.mock('child_process');
+
+afterEach(jest.clearAllMocks);
+
+describe('getCurrentBranchName', () => {
+  it('should return the current branch name', () => {
+    const branchName = 'master\n';
+    spawnSync.mockImplementation(() => {
+      return {
+        stdout: branchName,
+        stderr: null,
+      };
+    });
+
+    expect(getCurrentBranchName()).toEqual('master');
+    expect(spawnSync).toHaveBeenCalledWith('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      encoding: 'utf8',
+    });
+  });
+
+  it('should throw an error if it encounters an exception', () => {
+    spawnSync.mockImplementation(() => {
+      return {
+        stdout: null,
+        stderr: new Error('something not correct'),
+      };
+    });
+
+    expect(() => {
+      getCurrentBranchName();
+    }).toThrow('Error: something not correct');
+  });
+});
+
+describe('isGitRepository', () => {
+  it('should return true if the directory is a git repository', () => {
+    spawnSync.mockImplementation(() => {
+      return {
+        stdout: 'true',
+      };
+    });
+
+    expect(isGitRepository()).toBeTruthy();
+    expect(spawnSync).toHaveBeenCalledWith(
+      'git',
+      ['rev-parse', '--is-inside-work-tree'],
+      {
+        encoding: 'utf8',
+      }
+    );
+  });
+});
+
+describe('getGitRootDirPath', () => {
+  it('should return git root directory path', () => {
+    spawnSync.mockImplementation(() => {
+      return {
+        stdout: 'some/path/to\n',
+        stderr: null,
+      };
+    });
+
+    expect(getGitRootDirPath()).toEqual('some/path/to');
+    expect(spawnSync).toHaveBeenCalledWith('git', ['rev-parse', '--show-toplevel'], {
+      encoding: 'utf8',
+    });
+  });
+
+  it('should throw an error if it encounters an exception', () => {
+    spawnSync.mockImplementation(() => {
+      return {
+        stdout: null,
+        stderr: new Error('Boom!'),
+      };
+    });
+
+    expect(() => {
+      getGitRootDirPath();
+    }).toThrow('Error: Boom!');
+  });
+});

--- a/src/lib/__tests__/jenkins.spec.js
+++ b/src/lib/__tests__/jenkins.spec.js
@@ -198,6 +198,16 @@ describe('getJobLink', () => {
     expect(jobLink).toBe(expectedLink);
   });
 
+  it('should encode the branch name when it contains slashes', () => {
+    const branchName = 'feature/foo';
+    const jobLink = getJobLink(branchName);
+    const expectedLink = `${jenkinsCredentials.url}${
+      jobConfig.path
+    }/job/${encodeURIComponent(branchName)}`;
+
+    expect(jobLink).toBe(expectedLink);
+  });
+
   it('should throw an error for invalid job type', () => {
     jobConfig.type = 'Invalid job';
     const branchName = 'feature-x';

--- a/src/lib/git-cmd.js
+++ b/src/lib/git-cmd.js
@@ -3,13 +3,13 @@ const { spawnSync } = require('child_process');
 const { removeNewLine } = require('./util');
 
 exports.getCurrentBranchName = function() {
-  const { stdout, stderr } = spawnSync('git', ['symbolic-ref', 'HEAD'], {
+  const { stdout, stderr } = spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
     encoding: 'utf8',
   });
 
   if (stderr) throw new Error(stderr);
 
-  return removeNewLine(stdout.substr(stdout.lastIndexOf('/') + 1));
+  return removeNewLine(stdout);
 };
 
 exports.isGitRepository = function() {
@@ -17,7 +17,6 @@ exports.isGitRepository = function() {
     encoding: 'utf8',
   });
 
-  // error scenario `stderr` will be handled by the application
   return Boolean(stdout);
 };
 
@@ -28,5 +27,5 @@ exports.getGitRootDirPath = function() {
 
   if (stderr) throw new Error(stderr);
 
-  return removeNewLine(stdout.substr(stdout.lastIndexOf('\\') + 1));
+  return removeNewLine(stdout);
 };

--- a/src/lib/jenkins.js
+++ b/src/lib/jenkins.js
@@ -35,7 +35,7 @@ function getJobUrl(branchName, includeCredentials = true) {
       return `${baseUrl}${config.job.path}`;
 
     case JOB_TYPE.WorkflowMultiBranchProject:
-      return `${baseUrl}${config.job.path}/job/${branchName}`;
+      return `${baseUrl}${config.job.path}/job/${encodeURIComponent(branchName)}`;
 
     default:
       throw new Error(`Unsupported job type: ${config.job.type}`);

--- a/src/lib/prompt.js
+++ b/src/lib/prompt.js
@@ -13,7 +13,7 @@ function mapJob(job) {
   return {
     title: job.name,
     value: {
-      name: job.name,
+      name: job.name.trim(),
       path: removeTrailingSlash(url.parse(job.url).path),
       type: job.type,
     },


### PR DESCRIPTION
* Encoded (encodeURIComponent) the branch name before making any requests.
'foo/bar' => 'foo%2Fbar'

closes #63 