### PR TITLE
feat(build-cmd): option to interactively enable disabled job before triggering a build on it

### DIFF
--- a/src/commands/build/__tests__/assert-job-buildable.spec.js
+++ b/src/commands/build/__tests__/assert-job-buildable.spec.js
@@ -1,0 +1,81 @@
+const { enableJob, isJobBuildable } = require('../../../lib/jenkins');
+const { getConfirmationToEnableTheJob } = require('../../../lib/prompt');
+const { logNetworkErrors } = require('../../../lib/log');
+const assertJobBuildable = require('../assert-job-buildable');
+
+jest.mock('../../../lib/jenkins');
+jest.mock('../../../lib/prompt');
+jest.mock('../../../lib/log');
+
+const spinnerStub = {
+  start: jest.fn(),
+  stop: jest.fn(),
+  fail: jest.fn(),
+  succeed: jest.fn(),
+};
+const branchName = 'foo';
+
+describe('assertJobBuildable', () => {
+  beforeEach(() => {
+    isJobBuildable.mockImplementation(() => Promise.resolve(true));
+
+    // Note: mocked `process.exit` wont stop the execution
+    jest.spyOn(process, 'exit').mockImplementation(() => {});
+  });
+
+  afterEach(jest.clearAllMocks);
+
+  it('should not prompt confirmation when the job is buildable', async () => {
+    await assertJobBuildable(branchName, spinnerStub);
+
+    expect(spinnerStub.start).toHaveBeenCalledTimes(1);
+    expect(isJobBuildable).toHaveBeenCalledWith(branchName);
+    expect(getConfirmationToEnableTheJob).not.toHaveBeenCalled();
+  });
+
+  it('should catch all the exceptions locally', async () => {
+    const error = new Error('bar');
+    isJobBuildable.mockImplementation(() => Promise.reject(error));
+
+    await assertJobBuildable(branchName, spinnerStub);
+
+    expect(getConfirmationToEnableTheJob).not.toHaveBeenCalled();
+    expect(spinnerStub.fail).toHaveBeenCalledWith(error.message);
+    expect(logNetworkErrors).toHaveBeenCalledWith(error);
+    expect(process.exit).toHaveBeenCalled();
+  });
+
+  it('should prompt confirmation when the job is disabled', async () => {
+    isJobBuildable.mockImplementation(() => Promise.resolve(false));
+
+    await assertJobBuildable(branchName, spinnerStub);
+
+    expect(spinnerStub.stop).toHaveBeenCalled();
+    expect(getConfirmationToEnableTheJob).toHaveBeenCalled();
+  });
+
+  it('should end the process when the confirmation gets rejected', async () => {
+    getConfirmationToEnableTheJob.mockImplementation(() =>
+      Promise.resolve({ confirmation: false })
+    );
+    isJobBuildable.mockImplementation(() => Promise.resolve(false));
+
+    await assertJobBuildable(branchName, spinnerStub);
+
+    expect(spinnerStub.fail).toHaveBeenCalledWith('Aborted');
+    expect(process.exit).toHaveBeenCalledTimes(1);
+  });
+
+  it('should enable the job when the confirmation gets accepted', async () => {
+    getConfirmationToEnableTheJob.mockImplementation(() =>
+      Promise.resolve({ confirmation: false })
+    );
+    isJobBuildable.mockImplementation(() => Promise.resolve(false));
+
+    await assertJobBuildable(branchName, spinnerStub);
+
+    expect(spinnerStub.start).toHaveBeenNthCalledWith(2, 'Enabling the job');
+    expect(enableJob).toHaveBeenCalledWith(branchName);
+    expect(spinnerStub.succeed).toHaveBeenCalledWith('Job successfully enabled');
+  });
+});

--- a/src/commands/build/assert-job-buildable.js
+++ b/src/commands/build/assert-job-buildable.js
@@ -1,0 +1,29 @@
+const { enableJob, isJobBuildable } = require('../../lib/jenkins');
+const { getConfirmationToEnableTheJob } = require('../../lib/prompt');
+const { logNetworkErrors } = require('../../lib/log');
+
+async function assertJobBuildable(branchName, spinner) {
+  try {
+    spinner.start();
+
+    if (!(await isJobBuildable(branchName))) {
+      spinner.stop();
+
+      const { confirmation } = await getConfirmationToEnableTheJob();
+      if (!confirmation) {
+        spinner.fail('Aborted');
+        process.exit();
+      }
+
+      spinner.start('Enabling the job');
+      await enableJob(branchName);
+      spinner.succeed('Job successfully enabled');
+    }
+  } catch (error) {
+    spinner.fail(error.message);
+    logNetworkErrors(error);
+    process.exit();
+  }
+}
+
+module.exports = assertJobBuildable;

--- a/src/lib/prompt.js
+++ b/src/lib/prompt.js
@@ -127,3 +127,15 @@ exports.getDeleteConfigConfirmation = function() {
 
   return prompts(question);
 };
+
+exports.getConfirmationToEnableTheJob = function() {
+  const question = {
+    type: 'confirm',
+    name: 'confirmation',
+    message:
+      'The job is currently disabled. Do you like to enable and trigger a build on it',
+    initial: true,
+  };
+
+  return prompts(question);
+};


### PR DESCRIPTION
When the job is disabled, the build command prompts an option to enable the job and trigger a build on it.

closes #60 